### PR TITLE
ci: add Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,16 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  call:
+    uses: deg-labs/github-workflows/.github/workflows/dependabot-auto-merge.yml@main

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    name: Docker Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
Dependabot の PR を自動で squash マージする仕組みを追加します。

- 各リポジトリの `.github/workflows/dependabot-auto-merge.yml` が `pull_request` で発火し、`deg-labs/github-workflows` の再利用ワークフローを呼び出して `gh pr merge --auto --squash` を実行します。
- `dependabot[bot]` の PR のみ対象とし、人間の PR は自動マージしません。
- ビルドチェックの無かったリポジトリには CI ワークフローを追加し、ブランチルールセットの必須ステータスチェックを満たせるようにしています。

マージ後、Dependabot が開いた PR は該当するビルドチェック通過後に自動で squash マージされます。